### PR TITLE
fix aliases feature

### DIFF
--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -92,7 +92,7 @@ class FuzzyFinderView extends SelectListView
     else 
       # the path is an npm package name or an npm package subpath
       name = filePath
-      aliases = @getAliases
+      aliases = @getAliases()
       relativePath = @prettifyPath(filePath)
       if aliases[name]
         name = aliases[name]


### PR DESCRIPTION
The aliasses feature doesn't work, eg when you try to import `lodash` it imports like `lodash` instead of the default `_`.

I fixed this by adding parents here although I am not familiar with coffescript.