### PR TITLE
be able to set the declaration type on a require statement

### DIFF
--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -99,7 +99,8 @@ class FuzzyFinderView extends SelectListView
       else
         name = @getNameFromFilePath(relativePath)
     if @useOldRequireSyntax
-      editor.insertText("var " + name + " = require("+ "'" + relativePath + "')")
+      declaration = atom.config.get('node-requirer.requireDeclaration')
+      editor.insertText(declaration + " " + name + " = require("+ "'" + relativePath + "')")
     else 
       editor.insertText("import " + name + " from "+ "'" + relativePath + "'")
         

--- a/lib/fuzzy-finder-view2.js
+++ b/lib/fuzzy-finder-view2.js
@@ -99,7 +99,8 @@ module.exports = class FuzzyFinderView extends SelectListView {
       var relativePath = filePath;
     }
     if (this.useOldRequireSyntax) {
-      return editor.insertText(`var ${name} = require('${relativePath}')`);
+      const declaration = atom.config.get('node-requirer.requireDeclaration');
+      return editor.insertText(`${declaration} ${name} = require('${relativePath}')`);
     } else { 
       return editor.insertText(`import ${name} from '${relativePath}'`);
     }

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -35,6 +35,11 @@ module.exports =
       description: 'A list of alias to use for .',
       type: 'string',
       default: '{"lodash": "_","async":"a"}',
+    requireDeclaration:
+      title: 'Require declaration',
+      description: 'Define whether to use `const`, `let` or `var` as the declaration for the `require` statement',
+      type: 'string',
+      default: 'const',
 
   serialize: ->
     paths = {}


### PR DESCRIPTION
<img width="489" alt="screenshot 2017-02-26 16 12 13" src="https://cloud.githubusercontent.com/assets/11544418/23341385/5c07ae48-fc3e-11e6-8828-6e77f674c71f.png">

This PR adds a feature so you can set the variable declaration type in a require statement.

I have chosen to set the default to `const` rather than `var`. If you want I can change it back to `var` but I think `const` is probably more common now.

Also, I have updated `lib/fuzzy-finder-view.coffee` **and** `lib/fuzzy-finder-view2.js` I'm not sure whether both of these files are actually used but, let me know if one is unnecessary.

Closes #8 